### PR TITLE
Restore playlist screen title margin

### DIFF
--- a/frontend/components/AlbumHeader/styles.ts
+++ b/frontend/components/AlbumHeader/styles.ts
@@ -82,6 +82,7 @@ const styles = StyleSheet.create({
         justifyContent: 'flex-start',
         marginRight: 13,
         marginTop: 6,
+        marginLeft: 13,
         marginBottom: 2
     },
     headerText: {
@@ -129,7 +130,6 @@ const styles = StyleSheet.create({
         justifyContent: 'space-around',
     },
     promptText: {
-        
         color: '#3700AB',
         fontSize: 16,
         fontFamily: 'Avenir',


### PR DESCRIPTION
Accidentally deleted some margin code while merging the last pull request. Oops.

**Before:**
![image](https://user-images.githubusercontent.com/21225415/153804678-47523dd8-4e66-4f54-b618-1ca16f64a820.png)

**After:**
![image](https://user-images.githubusercontent.com/21225415/153804716-9fca4ddb-ccf9-4757-8ae0-6cf2e215d43a.png)
