### PR TITLE
Add basic fetch with new Swagger API / The One

### DIFF
--- a/frontend/screens/AlbumScreen.tsx
+++ b/frontend/screens/AlbumScreen.tsx
@@ -22,13 +22,16 @@ const AlbumScreen = ({ route, navigation }) => {
   const { obj, coords, initName } = route.params;
 
   const { authToken } = React.useContext(AppContext);
+  const [refreshToken, setRefreshToken] = useState(null);
 
-  const API_ENDPOINT = `http://localhost:4000/theOne/${coords.lat},${coords.long}/${authToken}`;
+  const API_ENDPOINT = `http://localhost:4000/theOne/${coords.lat},${coords.long}/`;
   const REQUEST_OPTIONS = {
     method: 'POST',
     body: JSON.stringify(obj),
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'access_token': authToken,
+      // 'refresh_token': refreshToken,
     }
   };
   // dummy API endpoint and request, to be replaced with user-input theOne parameters
@@ -53,7 +56,9 @@ const AlbumScreen = ({ route, navigation }) => {
         "trackIds": data.map(song => { return song.id })
       }),
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'access_token': authToken,
+        // 'refresh_token': refreshToken,
       }
     }
     fetch(NEW_ENDPOINT, NEW_OPTIONS)
@@ -146,7 +151,7 @@ const AlbumScreen = ({ route, navigation }) => {
       .then(response => response.json())
       .then(results => {
         console.log(results);
-        setData(results);
+        setData(results.body);
         setIsLoading(false);
       })
       .catch(err => {


### PR DESCRIPTION
Frontend can now interact with the new Swagger API, the same functionality as before. Pushing this to bring the API to main as quickly as possible (really sorry for the delays 😢), but there are still a few more things I need to take care of:

## Todo
- add helper on frontend to manage refresh_token and access_token swapping
- add helper specifically to handle requests, duplicated code is a bit hard to look at. Also, current implementation won't scale up well when we need more screens
- integrate tokens to authcontext @yan-alan 